### PR TITLE
Update README on its configuration on skeleton-typescript-webpack alike projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ npm install aurelia-plugins-google-recaptcha --save
 
 Add `node_modules/babel-polyfill/dist/polyfill.min.js` to the prepend list in `aurelia.json`. Do not forgot to add `babel-polyfill` to the dependencies in `package.json`.
 
+For projects without aurelia cli, like ***skeleton-typescript-webpack***, please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
+
+```
+module.exports = {
+  entry: ["babel-polyfill", "./app/js"]
+};
+```
+
 **JSPM**
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install aurelia-plugins-google-recaptcha --save
 
 Add `node_modules/babel-polyfill/dist/polyfill.min.js` to the prepend list in `aurelia.json`. Do not forgot to add `babel-polyfill` to the dependencies in `package.json`.
 
-For projects without aurelia cli, like ***skeleton-typescript-webpack***, please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
+For projects following [skeleton-typescript-webpack](https://github.com/aurelia/skeleton-navigation/tree/master/skeleton-typescript-webpack), please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
 
 ```
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ export class App {
     ValidationRules
       .ensure('response')
         .required().withMessage('Please verify the recaptcha.')
+        .on(this);
     this.validationController.addRenderer(new ValidationRenderer());
   }
   


### PR DESCRIPTION
1. configuration differs from aurelia-cli based projects
2. bug fix: without `.on(this);`, the validation won't work, meaning, you can by-pass the recaptcha check because `errors.valid` will be always `true`.