### PR TITLE
Handle recaptcha expired event

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ npm install aurelia-plugins-google-recaptcha --save
 
 Add `node_modules/babel-polyfill/dist/polyfill.min.js` to the prepend list in `aurelia.json`. Do not forgot to add `babel-polyfill` to the dependencies in `package.json`.
 
+For projects without aurelia cli, like ***skeleton-typescript-webpack***, please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
+
+```
+module.exports = {
+  entry: ["babel-polyfill", "./app/js"]
+};
+```
+
 **JSPM**
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install aurelia-plugins-google-recaptcha --save
 
 Add `node_modules/babel-polyfill/dist/polyfill.min.js` to the prepend list in `aurelia.json`. Do not forgot to add `babel-polyfill` to the dependencies in `package.json`.
 
-For projects without aurelia cli, like ***skeleton-typescript-webpack***, please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
+For projects following [skeleton-typescript-webpack](https://github.com/aurelia/skeleton-navigation/tree/master/skeleton-typescript-webpack), please add `babel-polyfill` to your webpack.config.js as [documented by babeljs.io](https://babeljs.io/docs/usage/polyfill/#usage-in-node--browserify--webpack):
 
 ```
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ export class App {
     ValidationRules
       .ensure('response')
         .required().withMessage('Please verify the recaptcha.')
+        .on(this);
     this.validationController.addRenderer(new ValidationRenderer());
   }
   

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Assuming you have [aurelia-validation](https://github.com/aurelia/validation) co
 
 ```html
 <form submit.delegate="submit()">
-  <aup-google-recaptcha callback.call="recaptcha($event)" value.bind="response & validate"></aup-google-recaptcha>
+  <aup-google-recaptcha callback.call="recaptcha($event)" expire.call="recaptchaExpired($event)" value.bind="response & validate"></aup-google-recaptcha>
   <button type="submit">Submit</button>
 </form>
 ```
@@ -110,16 +110,16 @@ export class App {
     ValidationRules
       .ensure('response')
         .required().withMessage('Please verify the recaptcha.')
-<<<<<<< HEAD
-        .on(this);
-=======
       .on(this);
->>>>>>> upstream/master
     this.validationController.addRenderer(new ValidationRenderer());
   }
 
   recaptcha(response) {
     this.response = response;
+  }
+
+  recaptchaExpired(){
+    this.response = undefined;
   }
 
   async submit() {

--- a/dist/amd/aurelia-plugins-google-recaptcha-element.d.ts
+++ b/dist/amd/aurelia-plugins-google-recaptcha-element.d.ts
@@ -4,12 +4,12 @@ export declare class Recaptcha {
     _scriptPromise: any;
     badge: string;
     callback: any;
+    expire: any;
     size: string;
     theme: string;
     type: string;
     widgetId: any;
     constructor(element: any, config: any);
-    bind(): void;
-    _initialize(): Promise<void>;
+    bind(): Promise<void>;
     _loadApiScript(): void;
 }

--- a/dist/amd/aurelia-plugins-google-recaptcha-element.js
+++ b/dist/amd/aurelia-plugins-google-recaptcha-element.js
@@ -84,7 +84,7 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
     throw new Error('Decorating class property failed. Please ensure that transform-class-properties is enabled.');
   }
 
-  var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6;
+  var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7;
 
   var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement)('aup-google-recaptcha'), _dec2 = (0, _aureliaTemplating.noView)(), _dec3 = (0, _aureliaDependencyInjection.inject)(Element, _aureliaPluginsGoogleRecaptchaConfig.Config), _dec4 = (0, _aureliaTemplating.bindable)({ defaultBindingMode: _aureliaBinding.bindingMode.twoWay }), _dec(_class = _dec2(_class = _dec3(_class = (_class2 = function () {
     function Recaptcha(element, config) {
@@ -96,13 +96,15 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
 
       _initDefineProp(this, 'callback', _descriptor2, this);
 
-      _initDefineProp(this, 'size', _descriptor3, this);
+      _initDefineProp(this, 'expire', _descriptor3, this);
 
-      _initDefineProp(this, 'theme', _descriptor4, this);
+      _initDefineProp(this, 'size', _descriptor4, this);
 
-      _initDefineProp(this, 'type', _descriptor5, this);
+      _initDefineProp(this, 'theme', _descriptor5, this);
 
-      _initDefineProp(this, 'widgetId', _descriptor6, this);
+      _initDefineProp(this, 'type', _descriptor6, this);
+
+      _initDefineProp(this, 'widgetId', _descriptor7, this);
 
       this._config = config;
       this._element = element;
@@ -110,11 +112,7 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
       this._loadApiScript();
     }
 
-    Recaptcha.prototype.bind = function bind() {
-      this._initialize();
-    };
-
-    Recaptcha.prototype._initialize = function () {
+    Recaptcha.prototype.bind = function () {
       var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
@@ -124,7 +122,7 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
                 return this._scriptPromise;
 
               case 2:
-                this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
+                this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, 'expired-callback': this.expire, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
 
               case 3:
               case 'end':
@@ -134,11 +132,11 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
         }, _callee, this);
       }));
 
-      function _initialize() {
+      function bind() {
         return _ref.apply(this, arguments);
       }
 
-      return _initialize;
+      return bind;
     }();
 
     Recaptcha.prototype._loadApiScript = function _loadApiScript() {
@@ -172,22 +170,25 @@ define(['exports', 'aurelia-binding', 'aurelia-dependency-injection', 'aurelia-t
   }), _descriptor2 = _applyDecoratedDescriptor(_class2.prototype, 'callback', [_aureliaTemplating.bindable], {
     enumerable: true,
     initializer: null
-  }), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'size', [_aureliaTemplating.bindable], {
+  }), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'expire', [_aureliaTemplating.bindable], {
+    enumerable: true,
+    initializer: null
+  }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'size', [_aureliaTemplating.bindable], {
     enumerable: true,
     initializer: function initializer() {
       return 'normal';
     }
-  }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [_aureliaTemplating.bindable], {
+  }), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [_aureliaTemplating.bindable], {
     enumerable: true,
     initializer: function initializer() {
       return 'light';
     }
-  }), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'type', [_aureliaTemplating.bindable], {
+  }), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'type', [_aureliaTemplating.bindable], {
     enumerable: true,
     initializer: function initializer() {
       return 'image';
     }
-  }), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
+  }), _descriptor7 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
     enumerable: true,
     initializer: null
   })), _class2)) || _class) || _class) || _class);

--- a/dist/commonjs/aurelia-plugins-google-recaptcha-element.d.ts
+++ b/dist/commonjs/aurelia-plugins-google-recaptcha-element.d.ts
@@ -4,12 +4,12 @@ export declare class Recaptcha {
     _scriptPromise: any;
     badge: string;
     callback: any;
+    expire: any;
     size: string;
     theme: string;
     type: string;
     widgetId: any;
     constructor(element: any, config: any);
-    bind(): void;
-    _initialize(): Promise<void>;
+    bind(): Promise<void>;
     _loadApiScript(): void;
 }

--- a/dist/commonjs/aurelia-plugins-google-recaptcha-element.js
+++ b/dist/commonjs/aurelia-plugins-google-recaptcha-element.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Recaptcha = undefined;
 
-var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6;
+var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7;
 
 var _aureliaBinding = require('aurelia-binding');
 
@@ -72,13 +72,15 @@ var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement
 
     _initDefineProp(this, 'callback', _descriptor2, this);
 
-    _initDefineProp(this, 'size', _descriptor3, this);
+    _initDefineProp(this, 'expire', _descriptor3, this);
 
-    _initDefineProp(this, 'theme', _descriptor4, this);
+    _initDefineProp(this, 'size', _descriptor4, this);
 
-    _initDefineProp(this, 'type', _descriptor5, this);
+    _initDefineProp(this, 'theme', _descriptor5, this);
 
-    _initDefineProp(this, 'widgetId', _descriptor6, this);
+    _initDefineProp(this, 'type', _descriptor6, this);
+
+    _initDefineProp(this, 'widgetId', _descriptor7, this);
 
     this._config = config;
     this._element = element;
@@ -86,11 +88,7 @@ var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement
     this._loadApiScript();
   }
 
-  Recaptcha.prototype.bind = function bind() {
-    this._initialize();
-  };
-
-  Recaptcha.prototype._initialize = function () {
+  Recaptcha.prototype.bind = function () {
     var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
       return regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
@@ -100,7 +98,7 @@ var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement
               return this._scriptPromise;
 
             case 2:
-              this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
+              this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, 'expired-callback': this.expire, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
 
             case 3:
             case 'end':
@@ -110,11 +108,11 @@ var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement
       }, _callee, this);
     }));
 
-    function _initialize() {
+    function bind() {
       return _ref.apply(this, arguments);
     }
 
-    return _initialize;
+    return bind;
   }();
 
   Recaptcha.prototype._loadApiScript = function _loadApiScript() {
@@ -148,22 +146,25 @@ var Recaptcha = exports.Recaptcha = (_dec = (0, _aureliaTemplating.customElement
 }), _descriptor2 = _applyDecoratedDescriptor(_class2.prototype, 'callback', [_aureliaTemplating.bindable], {
   enumerable: true,
   initializer: null
-}), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'size', [_aureliaTemplating.bindable], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'expire', [_aureliaTemplating.bindable], {
+  enumerable: true,
+  initializer: null
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'size', [_aureliaTemplating.bindable], {
   enumerable: true,
   initializer: function initializer() {
     return 'normal';
   }
-}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [_aureliaTemplating.bindable], {
+}), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [_aureliaTemplating.bindable], {
   enumerable: true,
   initializer: function initializer() {
     return 'light';
   }
-}), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'type', [_aureliaTemplating.bindable], {
+}), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'type', [_aureliaTemplating.bindable], {
   enumerable: true,
   initializer: function initializer() {
     return 'image';
   }
-}), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
+}), _descriptor7 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
   enumerable: true,
   initializer: null
 })), _class2)) || _class) || _class) || _class);

--- a/dist/es2015/aurelia-plugins-google-recaptcha-element.d.ts
+++ b/dist/es2015/aurelia-plugins-google-recaptcha-element.d.ts
@@ -4,12 +4,12 @@ export declare class Recaptcha {
     _scriptPromise: any;
     badge: string;
     callback: any;
+    expire: any;
     size: string;
     theme: string;
     type: string;
     widgetId: any;
     constructor(element: any, config: any);
-    bind(): void;
-    _initialize(): Promise<void>;
+    bind(): Promise<void>;
     _loadApiScript(): void;
 }

--- a/dist/es2015/aurelia-plugins-google-recaptcha-element.js
+++ b/dist/es2015/aurelia-plugins-google-recaptcha-element.js
@@ -1,4 +1,4 @@
-var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6;
+var _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7;
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
@@ -59,13 +59,15 @@ export let Recaptcha = (_dec = customElement('aup-google-recaptcha'), _dec2 = no
 
     _initDefineProp(this, 'callback', _descriptor2, this);
 
-    _initDefineProp(this, 'size', _descriptor3, this);
+    _initDefineProp(this, 'expire', _descriptor3, this);
 
-    _initDefineProp(this, 'theme', _descriptor4, this);
+    _initDefineProp(this, 'size', _descriptor4, this);
 
-    _initDefineProp(this, 'type', _descriptor5, this);
+    _initDefineProp(this, 'theme', _descriptor5, this);
 
-    _initDefineProp(this, 'widgetId', _descriptor6, this);
+    _initDefineProp(this, 'type', _descriptor6, this);
+
+    _initDefineProp(this, 'widgetId', _descriptor7, this);
 
     this._config = config;
     this._element = element;
@@ -74,15 +76,11 @@ export let Recaptcha = (_dec = customElement('aup-google-recaptcha'), _dec2 = no
   }
 
   bind() {
-    this._initialize();
-  }
-
-  _initialize() {
     var _this = this;
 
     return _asyncToGenerator(function* () {
       yield _this._scriptPromise;
-      _this.widgetId = window.grecaptcha.render(_this._element, { badge: _this.badge, callback: _this.callback, sitekey: _this._config.get('siteKey'), size: _this.size, theme: _this.theme, type: _this.type });
+      _this.widgetId = window.grecaptcha.render(_this._element, { badge: _this.badge, callback: _this.callback, 'expired-callback': _this.expire, sitekey: _this._config.get('siteKey'), size: _this.size, theme: _this.theme, type: _this.type });
     })();
   }
 
@@ -109,22 +107,25 @@ export let Recaptcha = (_dec = customElement('aup-google-recaptcha'), _dec2 = no
 }), _descriptor2 = _applyDecoratedDescriptor(_class2.prototype, 'callback', [bindable], {
   enumerable: true,
   initializer: null
-}), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'size', [bindable], {
+}), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'expire', [bindable], {
+  enumerable: true,
+  initializer: null
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'size', [bindable], {
   enumerable: true,
   initializer: function () {
     return 'normal';
   }
-}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [bindable], {
+}), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [bindable], {
   enumerable: true,
   initializer: function () {
     return 'light';
   }
-}), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'type', [bindable], {
+}), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'type', [bindable], {
   enumerable: true,
   initializer: function () {
     return 'image';
   }
-}), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
+}), _descriptor7 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
   enumerable: true,
   initializer: null
 })), _class2)) || _class) || _class) || _class);

--- a/dist/system/aurelia-plugins-google-recaptcha-element.d.ts
+++ b/dist/system/aurelia-plugins-google-recaptcha-element.d.ts
@@ -4,12 +4,12 @@ export declare class Recaptcha {
     _scriptPromise: any;
     badge: string;
     callback: any;
+    expire: any;
     size: string;
     theme: string;
     type: string;
     widgetId: any;
     constructor(element: any, config: any);
-    bind(): void;
-    _initialize(): Promise<void>;
+    bind(): Promise<void>;
     _loadApiScript(): void;
 }

--- a/dist/system/aurelia-plugins-google-recaptcha-element.js
+++ b/dist/system/aurelia-plugins-google-recaptcha-element.js
@@ -3,7 +3,7 @@
 System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-templating', './aurelia-plugins-google-recaptcha-config'], function (_export, _context) {
   "use strict";
 
-  var bindingMode, inject, bindable, customElement, noView, Config, _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, Recaptcha;
+  var bindingMode, inject, bindable, customElement, noView, Config, _dec, _dec2, _dec3, _dec4, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, Recaptcha;
 
   function _asyncToGenerator(fn) {
     return function () {
@@ -106,13 +106,15 @@ System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-tem
 
           _initDefineProp(this, 'callback', _descriptor2, this);
 
-          _initDefineProp(this, 'size', _descriptor3, this);
+          _initDefineProp(this, 'expire', _descriptor3, this);
 
-          _initDefineProp(this, 'theme', _descriptor4, this);
+          _initDefineProp(this, 'size', _descriptor4, this);
 
-          _initDefineProp(this, 'type', _descriptor5, this);
+          _initDefineProp(this, 'theme', _descriptor5, this);
 
-          _initDefineProp(this, 'widgetId', _descriptor6, this);
+          _initDefineProp(this, 'type', _descriptor6, this);
+
+          _initDefineProp(this, 'widgetId', _descriptor7, this);
 
           this._config = config;
           this._element = element;
@@ -120,11 +122,7 @@ System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-tem
           this._loadApiScript();
         }
 
-        Recaptcha.prototype.bind = function bind() {
-          this._initialize();
-        };
-
-        Recaptcha.prototype._initialize = function () {
+        Recaptcha.prototype.bind = function () {
           var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
             return regeneratorRuntime.wrap(function _callee$(_context2) {
               while (1) {
@@ -134,7 +132,7 @@ System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-tem
                     return this._scriptPromise;
 
                   case 2:
-                    this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
+                    this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, 'expired-callback': this.expire, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
 
                   case 3:
                   case 'end':
@@ -144,11 +142,11 @@ System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-tem
             }, _callee, this);
           }));
 
-          function _initialize() {
+          function bind() {
             return _ref.apply(this, arguments);
           }
 
-          return _initialize;
+          return bind;
         }();
 
         Recaptcha.prototype._loadApiScript = function _loadApiScript() {
@@ -182,22 +180,25 @@ System.register(['aurelia-binding', 'aurelia-dependency-injection', 'aurelia-tem
       }), _descriptor2 = _applyDecoratedDescriptor(_class2.prototype, 'callback', [bindable], {
         enumerable: true,
         initializer: null
-      }), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'size', [bindable], {
+      }), _descriptor3 = _applyDecoratedDescriptor(_class2.prototype, 'expire', [bindable], {
+        enumerable: true,
+        initializer: null
+      }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'size', [bindable], {
         enumerable: true,
         initializer: function initializer() {
           return 'normal';
         }
-      }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [bindable], {
+      }), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'theme', [bindable], {
         enumerable: true,
         initializer: function initializer() {
           return 'light';
         }
-      }), _descriptor5 = _applyDecoratedDescriptor(_class2.prototype, 'type', [bindable], {
+      }), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'type', [bindable], {
         enumerable: true,
         initializer: function initializer() {
           return 'image';
         }
-      }), _descriptor6 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
+      }), _descriptor7 = _applyDecoratedDescriptor(_class2.prototype, 'widgetId', [_dec4], {
         enumerable: true,
         initializer: null
       })), _class2)) || _class) || _class) || _class));

--- a/src/aurelia-plugins-google-recaptcha-element.js
+++ b/src/aurelia-plugins-google-recaptcha-element.js
@@ -24,6 +24,7 @@ export class Recaptcha {
   // BINDABLE PROPERTIES
   @bindable badge = 'bottomright';
   @bindable callback;
+  @bindable expire;
   @bindable size = 'normal';
   @bindable theme = 'light';
   @bindable type = 'image';
@@ -40,7 +41,7 @@ export class Recaptcha {
   // LIFECYCLE HANDLERS
   async bind() {
     await this._scriptPromise;
-    this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
+    this.widgetId = window.grecaptcha.render(this._element, { badge: this.badge, callback: this.callback, 'expired-callback': this.expire, sitekey: this._config.get('siteKey'), size: this.size, theme: this.theme, type: this.type });
   }
 
   // PRIVATE METHODS


### PR DESCRIPTION
With the existing plugin, there is no way to capture the recaptcha expired event from google recaptcha. Hence, user can bypass the expired recaptcha check and perform the guarded action.

https://developers.google.com/recaptcha/docs/display#render_param